### PR TITLE
End a Statement if an Empty one follows

### DIFF
--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -42,7 +42,7 @@ pub fn statement(tokens: TokenList) -> ParseResult<Statement> {
         }
     }
 
-    // Statement can end if the last token is an empty statement.
+    // Statement can end if the next token is an empty statement.
     if let Some(last_item) = next_tokens.next() {
         if let TokenType::Empty = last_item.token.ty {
             return Ok((next_tokens, statement));

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -42,6 +42,13 @@ pub fn statement(tokens: TokenList) -> ParseResult<Statement> {
         }
     }
 
+    // Statement can end if the last token is an empty statement.
+    if let Some(last_item) = next_tokens.next() {
+        if let TokenType::Empty = last_item.token.ty {
+            return Ok((next_tokens, statement));
+        }
+    }
+
     Err(next_tokens.error_before(ParseErrorType::ExpectedEndOfStatement))
         .with_context_from(ContextType::Statement, tokens)
 }


### PR DESCRIPTION
currently the parser crashes on code like this `fn() // test`, since the statement isn't ended by a semicolon or a newline. (so in contrast, this parses correctly: `fn(); // test`)

This PR ends a statement if an empty one follows.